### PR TITLE
Ghost template - Port url

### DIFF
--- a/System/Engine/Ghost/Template.php
+++ b/System/Engine/Ghost/Template.php
@@ -13,6 +13,7 @@
 namespace Silver\Engine\Ghost;
 
 use Silver\Core\Blueprints\RenderInterface;
+use Silver\Core\Env;
 use Silver\Core\Kernel;
 use Silver\Core\Route;
 use Silver\Http\Session;
@@ -63,7 +64,12 @@ class Template implements RenderInterface
         $render = $this->parseTrans($render);
 
         $render = $this->parseExtends($render);
-        // $render = $this->parseUrl($render); // url()
+        
+        if(!empty(Env::get('port')))
+        {
+            $render = $this->parseUrl($render); // url()
+        }
+        
         $render = $this->parseAssets($render); // asset()
         $render = $this->parseAssetsCss($render); // asset()
         $render = $this->parseAssetsJs($render); // asset()

--- a/local.env.php
+++ b/local.env.php
@@ -9,6 +9,7 @@
 return [
     'debug'         => true,
     'app_key'       => 'mysupersecurekey',
+    'port'          => false,
 
 
     'middlewares'   => [


### PR DESCRIPTION
- [Modified] [file:local.env] New index "port", indicating whether the server uses a port other than 80
- [Modified] [class:Silver\Engine\Ghost\Template] [Method:render] If the "port" is true, parse the url of the view.

resolve #23 